### PR TITLE
fix for adding 'similar' named search options

### DIFF
--- a/ml-modules/options/similar.xml
+++ b/ml-modules/options/similar.xml
@@ -1,0 +1,34 @@
+<options xmlns="http://marklogic.com/appservices/search">
+  <search-option>unfiltered</search-option>
+  <page-length>10</page-length>
+
+  <!-- Limit all searches to this additional query -->
+  <additional-query>
+    <cts:collection-query xmlns:cts="http://marklogic.com/cts">
+      <cts:uri>data</cts:uri>
+    </cts:collection-query>
+  </additional-query>
+
+  <!-- Full-text search options -->
+  <term apply="term">
+    <empty apply="all-results"/>
+    <!--
+      Below some example options for full-text searches. Note that MarkLogic will
+      toggle options automatically depending on caps, wildcards etc.
+      See Usage Notes of http://docs.marklogic.com/cts:word-query for details.
+      Also note that forcing stemmed searches will disable wildcarded searches.
+    -->
+    <!--
+    <term-option>punctuation-insensitive</term-option>
+    <term-option>stemmed</term-option>
+    -->
+  </term>
+
+  <constraint name="similar">
+    <custom facet="false">
+      <parse apply="parse-structured" ns="http://marklogic.com/similar" at="/lib/similar.xqy"/>
+    </custom>
+  </constraint>
+
+
+</options>

--- a/ml-modules/root/lib/similar.xqy
+++ b/ml-modules/root/lib/similar.xqy
@@ -1,0 +1,32 @@
+xquery version "1.0-ml";
+
+module namespace similar = "http://marklogic.com/similar";
+
+import module namespace impl = "http://marklogic.com/appservices/search-impl" at "/MarkLogic/appservices/search/search-impl.xqy";
+import module namespace functx = "http://www.functx.com" at "/MarkLogic/functx/functx-1.0-nodoc-2007-01.xqy";
+import schema namespace opt = "http://marklogic.com/appservices/search" at "search.xsd";
+
+declare namespace search = "http://marklogic.com/appservices/search";
+declare namespace searchdev = "http://marklogic.com/appservices/search/searchdev";
+declare default function namespace "http://www.w3.org/2005/xpath-functions";
+
+declare option xdmp:mapping "false";
+
+declare function similar:parse-structured(
+        $query-elem as item(),
+        $options as element()
+)
+as schema-element(cts:query)
+{
+if ($query-elem instance of element(search:query))
+then ()
+else if ($query-elem instance of element(search:custom-constraint-query))
+then let $uri := $query-elem/search:text/text()
+
+let $serialize := <elem>{cts:similar-query(doc($uri))}</elem>
+return $serialize/cts:similar-query
+
+else fn:error(xs:QName("ERROR"), "constraint similar error ")
+
+};
+


### PR DESCRIPTION
Required for migrating from a direct fetch to extsimilar to using a custom constraint to get 'similar' results. @grtjn Please review. :)